### PR TITLE
Resolves #133 [BUG]:Mobile Navigation Box Does Not Automatically Close When Navigating

### DIFF
--- a/client/src/components/header/header.tsx
+++ b/client/src/components/header/header.tsx
@@ -13,7 +13,7 @@ const Header: FC = () => {
   const { breakpoints } = useTheme()
   const matchMobileView = useMediaQuery(breakpoints.down('md'))
   const toggleMenu = () => {
-    setVisibleMenu(!visibleMenu);
+    setVisibleMenu(visibleMenu => !visibleMenu);
   };
   return (
     <Box sx={{ backgroundColor: 'background.paper', position: 'sticky', top: 0, zIndex: 1000 }}>

--- a/client/src/components/header/header.tsx
+++ b/client/src/components/header/header.tsx
@@ -12,7 +12,9 @@ const Header: FC = () => {
   const [visibleMenu, setVisibleMenu] = useState<boolean>(false)
   const { breakpoints } = useTheme()
   const matchMobileView = useMediaQuery(breakpoints.down('md'))
-
+  const toggleMenu = () => {
+    setVisibleMenu(!visibleMenu);
+  };
   return (
     <Box sx={{ backgroundColor: 'background.paper', position: 'sticky', top: 0, zIndex: 1000 }}>
       <Container sx={{ py: { xs: 2, md: 3 } }}>
@@ -44,7 +46,7 @@ const Header: FC = () => {
             }}
           >
             <Box /> {/* Magic space */}
-            <Navigation />
+            <Navigation toggleMenu={toggleMenu}/>
             <AuthNavigation />
             {visibleMenu && matchMobileView && (
               <IconButton

--- a/client/src/components/home/feature.tsx
+++ b/client/src/components/home/feature.tsx
@@ -119,7 +119,7 @@ const HomeFeature: FC = () => {
                   >
                     <Typography variant="h4" sx={{ color: '#32dc88' }}>
                       73%
-                    </Typography>
+                    </Typography> 
                     <CircularProgress
                       sx={{ position: 'absolute', color: 'divider' }}
                       thickness={2}
@@ -128,7 +128,7 @@ const HomeFeature: FC = () => {
                       size={85}
                     />
                     <CircularProgress
-                      disableShrink
+                      // disableShrink
                       thickness={2}
                       variant="determinate"
                       value={73}

--- a/client/src/components/navigation/navigation.tsx
+++ b/client/src/components/navigation/navigation.tsx
@@ -3,7 +3,11 @@ import Box from '@mui/material/Box'
 import { Link as ScrollLink } from 'react-scroll'
 import { navigations } from './navigation.data'
 
-const Navigation: FC = () => {
+interface NavigationProps {
+  toggleMenu: () => void; // Function to toggle the visibility of the navigation box
+}
+
+const Navigation: FC<NavigationProps> = ({toggleMenu }) => {
   return (
     <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' } }}>
       {navigations.map(({ path: destination, label }) => (
@@ -41,6 +45,7 @@ const Navigation: FC = () => {
               },
             },
           }}
+          onClick={toggleMenu}
         >
           <Box
             sx={{

--- a/client/src/components/navigation/navigation.tsx
+++ b/client/src/components/navigation/navigation.tsx
@@ -3,11 +3,11 @@ import Box from '@mui/material/Box'
 import { Link as ScrollLink } from 'react-scroll'
 import { navigations } from './navigation.data'
 
-interface NavigationProps {
+interface NavigationToggle {
   toggleMenu: () => void; // Function to toggle the visibility of the navigation box
 }
 
-const Navigation: FC<NavigationProps> = ({toggleMenu }) => {
+const Navigation: FC<NavigationToggle> = ({toggleMenu }) => {
   return (
     <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' } }}>
       {navigations.map(({ path: destination, label }) => (


### PR DESCRIPTION
## Pull Request Details

### Description

To close the responsive navigation box when a navigation item is clicked
### Fixes

Now when user chooses any path in navigation box , it gets closed automatically .

Issue #133 

### Type of PR

- [x] Bug fix


### Checklist
- [ ] I have read and followed the [Contribution Guidelines](https://github.com/omrajsharma/bigohhh.com/blob/main/Contribution.md).
- [ ] I have tested the changes thoroughly before submitting this pull request.
- [ ] I have provided relevant issue numbers, snapshots, and videos after making the changes.
- [ ] I have not borrowed code without disclosing it, if applicable.
- [ ] This pull request is not a Work In Progress (WIP), and only completed and tested changes are included.
- [ ] I have tested these changes locally.