### PR TITLE
changed Get Started and Subscribe button color while hovering

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "@mui/icons-material": "^5.6.2",
     "@mui/material": "^5.6.2",
     "next": "12.1.5",
+    
     "react": "18.0.0",
     "react-dom": "18.0.0",
     "react-scroll": "^1.8.7",

--- a/client/src/components/home/newsletter.tsx
+++ b/client/src/components/home/newsletter.tsx
@@ -46,7 +46,7 @@ const HomeNewsLetter: FC = () => {
               placeholder="Enter your Email Address"
             />
             <Box>
-              <StyledButton disableHoverEffect size="large">
+              <StyledButton  size="large">
                 Subscribe
               </StyledButton>
             </Box>

--- a/client/src/components/styled-button/styled-button.tsx
+++ b/client/src/components/styled-button/styled-button.tsx
@@ -41,13 +41,16 @@ const StyledButtonRoot = styled('button', {
   outline: 'none !important',
   transition: theme.transitions.create(['transform']),
 
-  // hover
+  //hover
   '&:hover': {
-    ...(!disableHoverEffect && {
-      transform: 'translateY(-3px)',
+     ...(!disableHoverEffect && {
+     transform: 'translateY(-3px)',
     }),
-  },
-
+  ...(color === 'primary' && {
+    backgroundColor: theme.palette.primary.dark,
+    color: theme.palette.primary.contrastText,
+  }),
+   },
   '& svg': {
     fontSize: 20,
   },

--- a/server/index.js
+++ b/server/index.js
@@ -17,7 +17,7 @@ app.get('/', (req, res) => {
 });
 
 // Start the server
-const PORT = process.env.PORT || 8080;
+const PORT = process.env.PORT || 8000;
 app.listen(PORT, () => {
     console.log(`Server is running on port ${PORT}`);
 });


### PR DESCRIPTION
## Pull Request Details
changed Get Started and Subscribe button color while hovering

### Description

Before, the color of the "**Get Started"** and **"Subscribe"** buttons did not change when hovering over them, which made them not feel like buttons.

media-
https://github.com/omrajsharma/bigohhh.com/assets/115336952/4b320652-5f85-4c81-b8a3-d726b8e414be



### Fixes
AFTER CHANGES
A nice button effect is achieved by changing the background color of the Get Started and Subscribe buttons when hovering.

https://github.com/omrajsharma/bigohhh.com/assets/115336952/5dfba775-a134-46af-b6a9-d419c9ab5610

https://github.com/omrajsharma/bigohhh.com/assets/115336952/6c765c4c-e57b-4fae-a8a0-b40d173ef55a




Fixes #109

### Type of PR

- [ ]  Feature enhancement


### Checklist
- 

-  [ ] I have read and followed the [Contribution Guidelines](https://github.com/omrajsharma/bigohhh.com/blob/main/Contribution.md).
- [ ] I have tested the changes thoroughly before submitting this pull request.
- [ ] I have provided relevant issue numbers, snapshots, and videos after making the changes.
- [ ] I have not borrowed code without disclosing it, if applicable.
- [ ] This pull request is not a Work In Progress (WIP), and only completed and tested changes are included.
- [ ] I have tested these changes locally.